### PR TITLE
Prevent multiple event bindings when calling .init.placeholder() manually

### DIFF
--- a/assets/javascripts/jquery.formalize.js
+++ b/assets/javascripts/jquery.formalize.js
@@ -19,6 +19,23 @@ var FORMALIZE = (function($, window, document, undefined) {
 			for (var i in FORMALIZE.init) {
 				FORMALIZE.init[i]();
 			}
+
+			if (!PLACEHOLDER_SUPPORTED && $(':input[placeholder]').length) {
+				$('form')
+					.submit(function() {
+						$(this).find(':input[placeholder]').each(function() {
+							var el = $(this),
+								text = el.attr('placeholder');
+
+							if (el.val() === text) {
+								el.val('').removeClass('placeholder_text');
+							}
+						});
+					})
+					.bind('reset', function() {
+						setTimeout(FORMALIZE.init.placeholder, 50);
+					});
+			}
 		},
 		// FORMALIZE.init
 		init: {
@@ -111,16 +128,6 @@ var FORMALIZE = (function($, window, document, undefined) {
 						}
 					}).blur(function() {
 						add_placeholder();
-					});
-
-					// Prevent <form> from accidentally
-					// submitting the placeholder text.
-					el.closest('form').submit(function() {
-						if (el.val() === text) {
-							el.val('').removeClass('placeholder_text');
-						}
-					}).bind('reset', function() {
-						setTimeout(add_placeholder, 50);
 					});
 				});
 			},


### PR DESCRIPTION
See what I did in the commit.

This could also be accomplished by adding a class to the form after binding the events once, then making sure that class doesn't exist before binding the events again.
