### PR TITLE
Typo in uncompressed version of jquery.formalize.js

### DIFF
--- a/assets/javascripts/jquery.formalize.js
+++ b/assets/javascripts/jquery.formalize.js
@@ -17,7 +17,7 @@ var FORMALIZE = (function($, window, document, undefined) {
     // FORMALIZE.go
     go: function() {
       for (var i in FORMALIZE.init) {
-        FORMALIZE.init[i](
+        FORMALIZE.init[i]();
       }
     },
     // FORMALIZE.init


### PR DESCRIPTION
Line 20 in the uncompressed version of jquery.formalize.js has a small typo in it (a set of parentheses that starts but doesn't end). The compressed version of the file works fine. 

(This is a super handy library, btw, thanks for putting it out there.)
