### PR TITLE
AddEvents on non-existent Form in Firefox 

### DIFF
--- a/assets/js/mootools.formalize.js
+++ b/assets/js/mootools.formalize.js
@@ -113,16 +113,24 @@ var FORMALIZE = (function(window, document, undefined) {
 
           // Prevent <form> from accidentally
           // submitting the placeholder text.
-          el.getParent('form').addEvents({
-            'submit': function() {
-              if (el.value === text) {
-                el.set('value', '').removeClass('placeholder_text');
+          
+          // note that some input elements might not have a parent form
+          // in older browsers addEvents() on a null object with throw an error
+          // check to ensure that the form exists before running addEvents on it
+          
+          var elementForm = el.getParent('form');
+          if(elementForm) {
+            el.getParent('form').addEvents({
+              'submit': function() {
+                if (el.value === text) {
+                  el.set('value', '').removeClass('placeholder_text');
+                }
+              },
+              'reset': function() {
+                setTimeout(FORMALIZE.misc.add_placeholder, 50);
               }
-            },
-            'reset': function() {
-              setTimeout(FORMALIZE.misc.add_placeholder, 50);
-            }
-          });
+            });
+          }
         });
       }
     },


### PR DESCRIPTION
Doesn't throw the error on Firefox 5, error is thrown on FF 3 and probably 4. 
