### PR TITLE
Changes to dojo.formalize.js to use dojo 1.7. 

### DIFF
--- a/assets/js/dojo.formalize.js
+++ b/assets/js/dojo.formalize.js
@@ -20,6 +20,21 @@ var FORMALIZE = (function(window, document, undefined) {
   var IE6 = IE(6);
   var IE7 = IE(7);
 
+  var dojoQuery;
+  var dojoConnect;
+  var dojoDomClass;
+
+  require( [ "dojo/query", "dojo/on", "dojo/dom-class", "dojo/dom-class" ],
+	  function( query, 
+		    on,
+		    domClass )
+	  {
+		  dojoQuery = query;
+		  dojoConnect = on;
+		  dojoDomClass = domClass
+	  }
+	 );
+
   // Expose innards of FORMALIZE.
   return {
     // FORMALIZE.go
@@ -34,13 +49,13 @@ var FORMALIZE = (function(window, document, undefined) {
     init: {
       // FORMALIZE.init.full_input_size
       full_input_size: function() {
-        if (!IE7 || !dojo.query('textarea, input.input_full').length) {
+        if (!IE7 || !dojoQuery('textarea, input.input_full').length) {
           return;
         }
 
         // This fixes width: 100% on <textarea> and class="input_full".
         // It ensures that form elements don't go wider than container.
-        dojo.query('textarea, input.input_full').forEach(function(el) {
+        dojoQuery('textarea, input.input_full').forEach(function(el) {
           var new_el = el.cloneNode(false);
           var span = document.createElement('span');
 
@@ -52,7 +67,7 @@ var FORMALIZE = (function(window, document, undefined) {
       // FORMALIZE.init.ie6_skin_inputs
       ie6_skin_inputs: function() {
         // Test for Internet Explorer 6.
-        if (!IE6 || !dojo.query('input, select, textarea').length) {
+        if (!IE6 || !dojoQuery('input, select, textarea').length) {
           // Exit if the browser is not IE6,
           // or if no form elements exist.
           return;
@@ -64,45 +79,45 @@ var FORMALIZE = (function(window, document, undefined) {
         // For <input type="text" />, etc.
         var type_regex = /date|datetime|datetime-local|email|month|number|password|range|search|tel|text|time|url|week/;
 
-        dojo.query('input').forEach(function(el) {
+        dojoQuery('input').forEach(function(el) {
           // Is it a button?
           if (el.getAttribute('type').match(button_regex)) {
-            dojo.addClass(el, 'ie6_button');
+            dojoDomClass.addClass(el, 'ie6_button');
 
             /* Is it disabled? */
             if (el.disabled) {
-              dojo.addClass(el, 'ie6_button_disabled');
+              dojoDomClass.addClass(el, 'ie6_button_disabled');
             }
           }
           // Or is it a textual input?
           else if (el.getAttribute('type').match(type_regex)) {
-            dojo.addClass(el, 'ie6_input');
+            dojoDomClass.addClass(el, 'ie6_input');
 
             /* Is it disabled? */
             if (el.disabled) {
-              dojo.addClass(el, 'ie6_input_disabled');
+              dojoDomClass.addClass(el, 'ie6_input_disabled');
             }
           }
         });
 
-        dojo.query('textarea, select').forEach(function(el) {
+        dojoQuery('textarea, select').forEach(function(el) {
           /* Is it disabled? */
           if (el.disabled) {
-            dojo.addClass(el, 'ie6_input_disabled');
+            dojoDomClass.addClass(el, 'ie6_input_disabled');
           }
         });
       },
       // FORMALIZE.init.autofocus
       autofocus: function() {
-        if (AUTOFOCUS_SUPPORTED || !dojo.query('[autofocus]').length) {
+        if (AUTOFOCUS_SUPPORTED || !dojoQuery('[autofocus]').length) {
           return;
         }
 
-        dojo.query('[autofocus]')[0].focus();
+        dojoQuery('[autofocus]')[0].focus();
       },
       // FORMALIZE.init.placeholder
       placeholder: function() {
-        if (PLACEHOLDER_SUPPORTED || !dojo.query('[placeholder]').length) {
+        if (PLACEHOLDER_SUPPORTED || !dojoQuery('[placeholder]').length) {
           // Exit if placeholder is supported natively,
           // or if page does not have any placeholder.
           return;
@@ -110,42 +125,42 @@ var FORMALIZE = (function(window, document, undefined) {
 
         FORMALIZE.misc.add_placeholder();
 
-        dojo.query('[placeholder]').forEach(function(el) {
+        dojoQuery('[placeholder]').forEach(function(el) {
           // Placeholder obscured in older browsers,
           // so there's no point adding to password.
           if (el.type === 'password') {
             return;
           }
 
-          dojo.connect(el, 'onfocus', function() {
+          dojoConnect(el, 'onfocus', function() {
             var text = el.getAttribute('placeholder');
 
             if (el.value === text) {
               el.value = '';
-              dojo.removeClass(el, 'placeholder_text');
+              dojoDomClass.removeClass(el, 'placeholder_text');
             }
           });
 
-          dojo.connect(el, 'onblur', function() {
+          dojoConnect(el, 'onblur', function() {
             FORMALIZE.misc.add_placeholder();
           });
         });
 
         // Prevent <form> from accidentally
         // submitting the placeholder text.
-        dojo.query('form').forEach(function(form) {
-          dojo.connect(form, 'onsubmit', function() {
-            dojo.query('[placeholder]', form).forEach(function(el) {
+        dojoQuery('form').forEach(function(form) {
+          dojoConnect(form, 'onsubmit', function() {
+            dojoQuery('[placeholder]', form).forEach(function(el) {
               var text = el.getAttribute('placeholder');
 
               if (el.value === text) {
                 el.value = '';
-                dojo.removeClass(el, 'placeholder_text');
+                dojoDomClass.removeClass(el, 'placeholder_text');
               }
             });
           });
 
-          dojo.connect(form, 'onreset', function() {
+          dojoConnect(form, 'onreset', function() {
             setTimeout(FORMALIZE.misc.add_placeholder, 50);
           });
         });
@@ -155,13 +170,13 @@ var FORMALIZE = (function(window, document, undefined) {
     misc: {
       // FORMALIZE.misc.add_placeholder
       add_placeholder: function() {
-        if (PLACEHOLDER_SUPPORTED || !dojo.query('[placeholder]').length) {
+        if (PLACEHOLDER_SUPPORTED || !dojoQuery('[placeholder]').length) {
           // Exit if placeholder is supported natively,
           // or if page does not have any placeholder.
           return;
         }
 
-        dojo.query('[placeholder]').forEach(function(el) {
+        dojoQuery('[placeholder]').forEach(function(el) {
           // Placeholder obscured in older browsers,
           // so there's no point adding to password.
           if (el.type === 'password') {
@@ -172,7 +187,7 @@ var FORMALIZE = (function(window, document, undefined) {
 
           if (!el.value || el.value === text) {
             el.value = text;
-            dojo.addClass(el, 'placeholder_text');
+            dojoDomClass.addClass(el, 'placeholder_text');
           }
         });
       }
@@ -182,6 +197,6 @@ var FORMALIZE = (function(window, document, undefined) {
 })(this, this.document);
 
 // Automatically calls all functions in FORMALIZE.init
-dojo.addOnLoad(function() {
+require( ["dojo/domReady!"], function() {
   FORMALIZE.go();
 });

--- a/assets/js/dojo.formalize.js
+++ b/assets/js/dojo.formalize.js
@@ -24,14 +24,14 @@ var FORMALIZE = (function(window, document, undefined) {
   var dojoConnect;
   var dojoDomClass;
 
-  require( [ "dojo/query", "dojo/on", "dojo/dom-class", "dojo/dom-class" ],
+  require( [ "dojo/query", "dojo/on", "dojo/dom-class", "dojo/domReady!" ],
 	  function( query, 
 		    on,
 		    domClass )
 	  {
 		  dojoQuery = query;
 		  dojoConnect = on;
-		  dojoDomClass = domClass
+		  dojoDomClass = domClass;
 	  }
 	 );
 
@@ -82,20 +82,20 @@ var FORMALIZE = (function(window, document, undefined) {
         dojoQuery('input').forEach(function(el) {
           // Is it a button?
           if (el.getAttribute('type').match(button_regex)) {
-            dojoDomClass.addClass(el, 'ie6_button');
+            dojoDomClass.add(el, 'ie6_button');
 
             /* Is it disabled? */
             if (el.disabled) {
-              dojoDomClass.addClass(el, 'ie6_button_disabled');
+              dojoDomClass.add(el, 'ie6_button_disabled');
             }
           }
           // Or is it a textual input?
           else if (el.getAttribute('type').match(type_regex)) {
-            dojoDomClass.addClass(el, 'ie6_input');
+            dojoDomClass.add(el, 'ie6_input');
 
             /* Is it disabled? */
             if (el.disabled) {
-              dojoDomClass.addClass(el, 'ie6_input_disabled');
+              dojoDomClass.add(el, 'ie6_input_disabled');
             }
           }
         });
@@ -103,7 +103,7 @@ var FORMALIZE = (function(window, document, undefined) {
         dojoQuery('textarea, select').forEach(function(el) {
           /* Is it disabled? */
           if (el.disabled) {
-            dojoDomClass.addClass(el, 'ie6_input_disabled');
+            dojoDomClass.add(el, 'ie6_input_disabled');
           }
         });
       },
@@ -137,7 +137,7 @@ var FORMALIZE = (function(window, document, undefined) {
 
             if (el.value === text) {
               el.value = '';
-              dojoDomClass.removeClass(el, 'placeholder_text');
+              dojoDomClass.remove(el, 'placeholder_text');
             }
           });
 
@@ -155,7 +155,7 @@ var FORMALIZE = (function(window, document, undefined) {
 
               if (el.value === text) {
                 el.value = '';
-                dojoDomClass.removeClass(el, 'placeholder_text');
+                dojoDomClass.remove(el, 'placeholder_text');
               }
             });
           });
@@ -187,7 +187,7 @@ var FORMALIZE = (function(window, document, undefined) {
 
           if (!el.value || el.value === text) {
             el.value = text;
-            dojoDomClass.addClass(el, 'placeholder_text');
+            dojoDomClass.add(el, 'placeholder_text');
           }
         });
       }


### PR DESCRIPTION
The changes made were minimal and tried to maintain the
structure before the change.

To better adapt to the module programming it might be
better to put this into a package so that calling
require( ["formalize"] );
would work more like in dojo.
